### PR TITLE
Creates initial modx script

### DIFF
--- a/php/loadPolyfill.php
+++ b/php/loadPolyfill.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * loadPolyfill
+ *
+ * Creates a local copy of Filament Groups rel="preload" polyfill
+ */
 $modx->getService('fileHandler','modFileHandler');
 $file = $modx->fileHandler->make('/assests/js/polyfill/');
 if (!$file->create('cssrelpreload.min.js')) {

--- a/php/loadPolyfill.php
+++ b/php/loadPolyfill.php
@@ -1,0 +1,10 @@
+<?php
+$modx->getService('fileHandler','modFileHandler');
+$file = $modx->fileHandler->make('/assests/js/polyfill/');
+if (!$file->create('cssrelpreload.min.js')) {
+   return $modx->log(modX::LOG_LEVEL_DEBUG, 'loadPolyfill was unable to create file preload.js');
+}
+
+file_put_contents($file->getPath(), 'https://cdnjs.cloudflare.com/ajax/libs/loadCSS/2.1.0/cssrelpreload.min.js');
+
+return $modx->log(modX::LOG_LEVEL_DEBUG, 'loadPolyfill created file preload.js');


### PR DESCRIPTION
Copied an example from
`https://docs.modx.com/revolution/2.x/developing-in-modx/advanced-development/modx-services/modfilehandler`

- makes a js file
- checks if the file actually is created
  - logs modx error if unsuccessful
- puts the contents of the polyfill from cdnjs
- returns a success message